### PR TITLE
Add sources of contracts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # contract-library
 Library of smart contracts
+
+### Sources of contracts
+
+|Name|Source|Version / Commit hash|License|
+|----|------|-------|-------|
+|Authorizable|ZeroEx| - |Apache 2.0|
+|Destructable| OpenZeppelin? | - | - |
+|ECDSA| [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/5471fc808a17342d738853d7bf3e9e5ef3108074/contracts/cryptography/ECDSA.sol)| 5471fc808a17342d738853d7bf3e9e5ef3108074 | MIT |
+|it_set_lib| trustlines-network | - | - |
+|Ownable| trustlines-network | - | - |
+|RLPReader| [rocket-pool](https://github.com/rocket-pool/rocketpool/blob/b4538a71c20c6f8daefc524427d820f69e1fbb56/contracts/lib/RLPReader.sol)| b4538a71c20c6f8daefc524427d820f69e1fbb56 |Apache 2.0|
+|SafeMath| OpenZeppelin? | - | - |


### PR DESCRIPTION
Some sources could not be tracked but I would guess they come from OpenZeppelin. When possible the hash of the commit from which the contract is taken has been added.
Related to https://github.com/trustlines-network/contract-library/issues/4