### PR TITLE
update ethlint-pre-commit to a non-broken version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     - id: no-commit-to-branch
       args: [--branch, develop, --branch, master]
 - repo: https://github.com/schmir/ethlint-pre-commit.git
-  rev: 'fc4f655fe2ad22a6f3668045a99b5cc1b21f79da'
+  rev: 'ceedc72aa232b9391840256c7781226a3e238b1a'
   hooks:
   - id: ethlint
+    exclude: contracts/ECDSA.sol|contracts/RLPReader.sol|contracts/TestRLPReader.sol


### PR DESCRIPTION
The old version didn't check all of the files supplied as arguments by
pre-commit.

Also ignore solidity files from external sources.